### PR TITLE
feat: implement loan extension feature

### DIFF
--- a/library_app/src/app/context.gleam
+++ b/library_app/src/app/context.gleam
@@ -35,6 +35,7 @@ pub type LoanOperations {
   LoanOperations(
     create: loan_command.CreateLoan,
     update: loan_command.ReturnLoan,
+    extend: loan_command.ExtendLoan,
     get: loan_query.GetLoan,
     get_all: loan_query.GetLoans,
   )
@@ -79,6 +80,7 @@ pub fn mock_repositories() -> Repositories {
       get_loan_by_id: fn(_) { Error(["not implemented"]) },
       save_loan: fn(_) { Ok(Nil) },
       put_loan: fn(_) { Ok(Nil) },
+      extend_loan: fn(_) { Ok(Nil) },
     ),
     schedule: schedule_repository.ScheduleRepository(
       get_specify_schedules: fn(_) { [] },
@@ -118,6 +120,12 @@ pub fn create_operations(ctx: Context, repos: Repositories) -> Operations {
         ctx.current_date,
         repos.loan.get_loan_by_id,
         repos.loan.put_loan,
+      ),
+      extend: loan_command.extend_loan_workflow(
+        ctx.current_date,
+        repos.schedule.get_specify_schedules,
+        repos.loan.get_loan,
+        repos.loan.extend_loan,
       ),
       get: repos.loan.get_loan,
       get_all: repos.loan.get_loans,

--- a/library_app/src/core/loan/domain/loan.gleam
+++ b/library_app/src/core/loan/domain/loan.gleam
@@ -19,6 +19,7 @@ pub type Loan {
     loan_date: date.Date,
     due_date: date.Date,
     return_date: option.Option(date.Date),
+    extension_count: Int,
   )
 }
 
@@ -50,6 +51,7 @@ pub fn new(
     loan_date: current_date,
     due_date:,
     return_date: option.None,
+    extension_count: 0,
   )
   |> Ok()
 }
@@ -57,6 +59,10 @@ pub fn new(
 // Getter functions for accessing opaque type fields
 pub fn id_value(loan: Loan) -> String {
   loan.id.value
+}
+
+pub fn id_from_string(value: String) -> LoanId {
+  LoanId(value)
 }
 
 fn is_overdue(loan: Loan, current_date: date.Date) -> Bool {
@@ -79,6 +85,46 @@ pub fn return_book(loan: Loan, return_date: date.Date) -> Result(Loan, String) {
     option.None -> {
       let loan = Loan(..loan, return_date: option.Some(return_date))
       Ok(loan)
+    }
+  }
+}
+
+pub fn extend_loan(
+  loan: Loan,
+  current_date: date.Date,
+  schedule_list: List(specify_schedule.SpecifySchedule),
+) -> Result(Loan, String) {
+  use validated_loan <- result.try(validate_extension_eligibility(loan, current_date))
+  
+  let new_due_date =
+    loan.due_date
+    |> date.add_days(14)
+    |> library_schedule.find_due_date(schedule_list)
+
+  use new_due_date <- result.try(new_due_date)
+
+  let extended_loan = Loan(
+    ..validated_loan,
+    due_date: new_due_date,
+    extension_count: validated_loan.extension_count + 1,
+  )
+  
+  Ok(extended_loan)
+}
+
+fn validate_extension_eligibility(loan: Loan, current_date: date.Date) -> Result(Loan, String) {
+  case loan.return_date {
+    option.Some(_) -> Error("返却済みの貸出は延長できません")
+    option.None -> {
+      case loan.extension_count >= 1 {
+        True -> Error("延長は1回までです")
+        False -> {
+          case is_overdue(loan, current_date) {
+            True -> Error("延滞中の貸出は延長できません")
+            False -> Ok(loan)
+          }
+        }
+      }
     }
   }
 }

--- a/library_app/src/core/loan/domain/loan_repository.gleam
+++ b/library_app/src/core/loan/domain/loan_repository.gleam
@@ -10,6 +10,7 @@ pub type LoanRepository {
     get_loan_by_id: GetLoanByBookId,
     save_loan: SaveLoan,
     put_loan: UpdateLoan,
+    extend_loan: ExtendLoan,
   )
 }
 
@@ -40,6 +41,9 @@ pub type CreateLoanParams {
 
 // update
 pub type UpdateLoan =
+  fn(loan.Loan) -> Result(Nil, List(String))
+
+pub type ExtendLoan =
   fn(loan.Loan) -> Result(Nil, List(String))
 
 pub type UpdateLoanParams {

--- a/library_app/src/shell/adapters/persistence/loan_repo_on_ets.gleam
+++ b/library_app/src/shell/adapters/persistence/loan_repo_on_ets.gleam
@@ -20,6 +20,7 @@ pub fn new() -> loan_repository.LoanRepository {
     get_loan_by_id: get_loan_by_id(_, conn),
     save_loan: save_loan(_, conn),
     put_loan: put_loan(_, conn),
+    extend_loan: extend_loan(_, conn),
   )
 }
 
@@ -69,5 +70,9 @@ fn save_loan(loan: loan.Loan, conn: LoanRepo) -> Result(Nil, List(String)) {
 }
 
 fn put_loan(loan: loan.Loan, conn: LoanRepo) -> Result(Nil, List(String)) {
+  conn.update(#(loan |> loan.id_value, loan))
+}
+
+fn extend_loan(loan: loan.Loan, conn: LoanRepo) -> Result(Nil, List(String)) {
   conn.update(#(loan |> loan.id_value, loan))
 }

--- a/library_app/src/shell/adapters/web/handler/loan_handler.gleam
+++ b/library_app/src/shell/adapters/web/handler/loan_handler.gleam
@@ -51,6 +51,7 @@ fn serialize(loan: loan.Loan) -> json.Json {
       loan.return_date
         |> json.map_or(date.to_string, "", json.string),
     ),
+    #("extension_count", loan.extension_count |> json.int()),
   ]
   |> json.object()
 }
@@ -60,6 +61,16 @@ pub fn update_loan_by_return_book(
   ops: context.Operations,
 ) -> wisp.Response {
   case ops.loan.update(book_id) {
+    Ok(_) -> wisp.no_content()
+    Error(error) -> json.bad_request(error |> json.array(json.string))
+  }
+}
+
+pub fn extend_loan(
+  loan_id: String,
+  ops: context.Operations,
+) -> wisp.Response {
+  case ops.loan.extend(loan_id) {
     Ok(_) -> wisp.no_content()
     Error(error) -> json.bad_request(error |> json.array(json.string))
   }

--- a/library_app/src/shell/adapters/web/router.gleam
+++ b/library_app/src/shell/adapters/web/router.gleam
@@ -22,6 +22,8 @@ pub fn handle_request(
       loan_handler.create_loan(req, ctx, ops, book_id)
     ["loans", book_id], Put ->
       loan_handler.update_loan_by_return_book(book_id, ops)
+    ["loans", loan_id, "extend"], Put ->
+      loan_handler.extend_loan(loan_id, ops)
     ["loans"], Get -> loan_handler.get_loans(req, ops)
     ["loans", id], Get -> loan_handler.get_loan(id, ops)
     ["health_check"], Get -> health_check()


### PR DESCRIPTION
## Summary
Implements loan extension functionality allowing users to extend loan periods by 14 days with a maximum of one extension per loan.

## Features Added
- **14-day loan extension** with holiday/schedule awareness
- **One-time extension limit** per loan (tracked via `extension_count`)
- **Comprehensive validation**:
  - ✅ Prevents extension of returned loans
  - ✅ Prevents extension of overdue loans  
  - ✅ Prevents multiple extensions
- **REST API endpoint**: `PUT /api/loans/{loan_id}/extend`

## Architecture & Design
- Follows existing **Functional Core, Imperative Shell** pattern
- Maintains **DDD bounded context** separation
- Uses established validation and error handling patterns
- Integrates seamlessly with library schedule system

## Changes Made
### Domain Layer
- Add `extension_count: Int` field to `Loan` type
- Implement `extend_loan()` function with comprehensive validation
- Add `validate_extension_eligibility()` helper function

### Application Layer  
- Create `extend_loan_workflow()` application service
- Add `ExtendLoan` type alias for consistency

### Infrastructure Layer
- Extend repository interfaces with `ExtendLoan` type
- Update ETS repository implementation
- Add loan extension HTTP handler
- Create REST endpoint routing

### Testing
- **Unit tests** for all validation scenarios:
  - ✅ Successful extension
  - ✅ Already extended (error)
  - ✅ Overdue loan (error)  
  - ✅ Already returned (error)
- **Integration tests** updated for new repository interface
- **Manual API testing** confirmed successful operation

## API Usage
```bash
# Extend a loan
PUT /api/loans/{loan_id}/extend

# Success: 204 No Content
# Error examples:
# 400 Bad Request: ["延長は1回までです"]
# 400 Bad Request: ["延滞中の貸出は延長できません"]
# 400 Bad Request: ["返却済みの貸出は延長できません"]
```

## JSON Response Changes
Loan objects now include `extension_count` field:
```json
{
  "id": "...",
  "book_id": "...",
  "loan_date": "2025-07-31",
  "due_date": "2025-08-28",
  "return_date": "",
  "extension_count": 1
}
```

## Breaking Changes ⚠️
- **Schema change**: `Loan` type now includes `extension_count: Int` field
- **API change**: JSON responses include new `extension_count` field
- **Repository interface**: Extended with `extend_loan` function

## Migration Notes
Existing loan records will need `extension_count` field initialized to `0`.

## Test Plan
- [x] Unit tests pass for all validation scenarios
- [x] Integration tests updated and passing
- [x] Manual API testing successful
- [x] Extension count properly tracked
- [x] Holiday integration working correctly
- [x] Error messages clear and appropriate

🤖 Generated with [Claude Code](https://claude.ai/code)